### PR TITLE
Share the logs as text (instead of as a file)

### DIFF
--- a/app/src/main/java/com/osunick/voicerecorder/VoiceRecorderActivity.kt
+++ b/app/src/main/java/com/osunick/voicerecorder/VoiceRecorderActivity.kt
@@ -118,19 +118,12 @@ class VoiceRecorderActivity : ComponentActivity() {
 
     private fun share() {
         lifecycleScope.launch {
-            val file: File = viewModel.createFile(logsDir())
-            val fileUri = FileProvider.getUriForFile(
-                this@VoiceRecorderActivity,
-                packageName.plus(".fileprovider"),
-                file
-            )
             val shareIntent: Intent = Intent().apply {
                 action = Intent.ACTION_SEND
-                putExtra(Intent.EXTRA_STREAM, fileUri)
+                putExtra(Intent.EXTRA_TEXT, viewModel.createDataString())
                 type = "text/plain"
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
-            startActivity(Intent.createChooser(shareIntent, getString(R.string.share_file)))
+            startActivity(Intent.createChooser(shareIntent, getString(R.string.share_logs)))
         }
     }
 

--- a/app/src/main/java/com/osunick/voicerecorder/viewmodel/LogsViewModel.kt
+++ b/app/src/main/java/com/osunick/voicerecorder/viewmodel/LogsViewModel.kt
@@ -66,7 +66,8 @@ class LogsViewModel @Inject constructor(
         if (!message.isNullOrBlank()) {
             val voiceMessage = VoiceMessage(
                 text = message,
-                dateTime = ZonedDateTime.now().withZoneSameInstant(UTCZoneId))
+                dateTime = ZonedDateTime.now().withZoneSameInstant(UTCZoneId)
+            )
             viewModelScope.launch {
                 messageRepository.addMessage(voiceMessage)
             }
@@ -97,7 +98,8 @@ class LogsViewModel @Inject constructor(
     fun saveVoiceRecording(text: String) {
         val voiceMessage = VoiceMessage(
             text = text,
-            dateTime = ZonedDateTime.now().withZoneSameInstant(UTCZoneId))
+            dateTime = ZonedDateTime.now().withZoneSameInstant(UTCZoneId)
+        )
         viewModelScope.launch {
             messageRepository.addMessage(voiceMessage)
         }
@@ -127,24 +129,16 @@ class LogsViewModel @Inject constructor(
         }
     }
 
-    suspend fun createFile(logsDir: File): File =
+    // This is for sharing.  We can only share a max of 1MB, but we're going to assume that the
+    // amount of data is less than that and not handle the overflow case (for now).
+    suspend fun createDataString(): String =
         withContext(Dispatchers.IO) {
-            val logFile = File.createTempFile("logs", ".txt", logsDir)
-            val fos = FileOutputStream(logFile, false)
-            try {
-                val header = "UTC Date\tLocal Date\tLabel\tLog\n"
-                fos.write(header.toByteArray())
+            buildString {
+                append("UTC Date\tLocal Date\tLabel\tLog\n")
                 messageRepository.getAllMessages().forEach {
-                    val line = "${formatUTC(it.dateTime)}\t${formatLocal(it.dateTime)}\t${it.label}\t${it.text}\n"
-                    fos.write(line.toByteArray())
+                    append("${formatUTC(it.dateTime)}\t${formatLocal(it.dateTime)}\t${it.label}\t${it.text}\n")
                 }
-            } catch (ioe: IOException) {
-                Log.e("CreateFile", "Something went wrong", ioe)
-            } finally {
-                fos.flush()
-                fos.close()
             }
-            logFile
         }
 
     private fun formatUTC(zonedDateTime: ZonedDateTime) =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="cannot_recognize_speech_without_this_permission">Cannot recognize speech without this permission</string>
     <string name="audio_permission_required">Audio Permission Required</string>
     <string name="need_audio_permission">Audio permission is required to create notes from your voice</string>
-    <string name="share_file">Share log file</string>
+    <string name="share_logs">Share voice logs</string>
     <string name="record">Record</string>
     <string name="add_widget">Add widget</string>
     <string name="app_widget_description">This is an app widget description</string>


### PR DESCRIPTION
Instead of sharing the data out as a file, we'll share it as text instead.

Note: there is a 1MB limit on how much text we can send (and we aren't handling that in any way).